### PR TITLE
Avoid breaks mockserver when a mockRequest doesnt exists

### DIFF
--- a/middlewares/mock.js
+++ b/middlewares/mock.js
@@ -41,11 +41,9 @@ module.exports = ({ server, dbService }) => async (req, res, next) => {
   const uri = `http://${URI_API}${parsedUrl.path}`;
   let mockRequest = dbService.onRequests.getTo({ method, url: uri });
 
-	let delay = 0;
-
-	if(mockRequest) {
-		delay = mockRequest.delay || 0;
-	}
+  if (!mockRequest) return
+	
+  let delay =  mockRequest.delay || 0;
 	
 	setTimeout(async () => {
 		if (!server.locals.requestApi) {


### PR DESCRIPTION
This change avoids server to do not break when a mockRequest isn't find it. The problem doesnt stops the application but shows confusing messages on console.